### PR TITLE
Terser way to fall back from astropy.wcs to pywcs

### DIFF
--- a/aplpy/wcs_util.py
+++ b/aplpy/wcs_util.py
@@ -1,14 +1,9 @@
 import numpy as np
 
 try:
-    import pywcs
-except ImportError:
-    pass
-
-try:
     from astropy import wcs as pywcs
 except ImportError:
-    pass
+    import pywcs
 
 from .logger import logger
 


### PR DESCRIPTION
This avoids importing pywcs at all if astropy.wcs is present. Also,
if neither astropy.wcs nor pywcs is available, the exception will be
an ImportError.
