### PR TITLE
Allow user to specify an axis instead of a figure

### DIFF
--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -243,7 +243,11 @@ class FITSFigure(Layers, Regions, Deprecated):
             if hasattr(axis,'toggle_axisline'):
                 self._ax1 = axis
             else:
-                # Hack-ish; there must be a better way
+                # If the axis is an incompatible axis type, create a compatible
+                # axis type that is in the same location
+                log.warning("The specified axis is missing some features "
+                            "aplpy needs.  A new axis at the same location "
+                            "is being created.")
                 lower_corner = axis.get_position()[0,:]
                 extent = axis.get_position()[1:] - lower_corner
                 cornerpars = np.concatenate([lower_corner,extent])

--- a/aplpy/tests/test_init_image.py
+++ b/aplpy/tests/test_init_image.py
@@ -180,3 +180,11 @@ def test_init_single_pixel():
     data[2,2] = 1
     f = FITSFigure(data)
     f.show_grayscale()
+
+def test_axis_init():
+    hdu = generate_hdu(REFERENCE)
+    fig = matplotlib.pyplot.figure()
+    axis = fig.gca()
+    f = FITSFigure(hdu, axis=axis)
+    f.show_grayscale()
+    f.close()


### PR DESCRIPTION
I found myself wanting to use matplotlib/pylab's built-in `subplot` routine and then have aplpy plot on one of those axes, so I tried implementing that. Unfortunately, aplpy requires a `ParasiteAxes`/`HostAxes` instance.  I tried creating one (see commented out code), but right now this just raises an exception if the wrong type of axis is specified.

This may need to be rebased against the latest astropy refactor... 
