### PR TITLE
_PACKAGE_SETUP_ should be _ASTROPY_SETUP_

### DIFF
--- a/aplpy/__init__.py
+++ b/aplpy/__init__.py
@@ -2,14 +2,14 @@
 
 #this indicates whether or not we are in the package's setup.py
 try:
-    _PACKAGE_SETUP_
+    _ASTROPY_SETUP_
 except NameError:
     from sys import version_info
     if version_info[0] >= 3:
         import builtins
     else:
         import __builtin__ as builtins
-    builtins._PACKAGE_SETUP_ = False
+    builtins._ASTROPY_SETUP_ = False
     del version_info
 
 try:
@@ -101,7 +101,7 @@ def test(package=None, test_path=None, args=None, plugins=None,
         remote_data=remote_data, pep8=pep8, pdb=pdb,
         coverage=coverage, open_files=open_files, **kwargs)
 
-if not _PACKAGE_SETUP_:
+if not _ASTROPY_SETUP_:
 
     import os
     from warnings import warn

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if sys.version_info[0] >= 3:
     import builtins
 else:
     import __builtin__ as builtins
-builtins._PACKAGE_SETUP_ = True
+builtins._ASTROPY_SETUP_ = True
 
 import astropy
 from astropy.setup_helpers import (register_commands, adjust_compiler,


### PR DESCRIPTION
This should fix installation errors in Python 3.
