### PR TITLE
Draw the grid on the whole figure

### DIFF
--- a/aplpy/aplpy.py
+++ b/aplpy/aplpy.py
@@ -503,10 +503,10 @@ class FITSFigure(Layers, Regions, Deprecated):
 
     @auto_refresh
     def show_grayscale(self, vmin=None, vmid=None, vmax=None,
-                            pmin=0.25, pmax=99.75,
-                            stretch='linear', exponent=2, invert='default',
-                            smooth=None, kernel='gauss', aspect='equal',
-                            interpolation='nearest'):
+                       pmin=0.25, pmax=99.75,
+                       stretch='linear', exponent=2, invert='default',
+                       smooth=None, kernel='gauss', aspect='equal',
+                       interpolation='nearest'):
         '''
         Show a grayscale image of the FITS file.
 
@@ -703,7 +703,10 @@ class FITSFigure(Layers, Regions, Deprecated):
                                                        smooth=smooth,
                                                        kernel=kernel))
         else:
-            self.image = self._ax1.imshow(convolve_util.convolve(self._data, smooth=smooth, kernel=kernel), cmap=cmap, interpolation=interpolation, origin='lower', extent=self._extent, norm=normalizer, aspect=aspect)
+            self.image = self._ax1.imshow(
+                convolve_util.convolve(self._data, smooth=smooth, kernel=kernel),
+                cmap=cmap, interpolation=interpolation, origin='lower',
+                extent=self._extent, norm=normalizer, aspect=aspect)
 
         xmin, xmax = self._ax1.get_xbound()
         if xmin == 0.0:

--- a/aplpy/grid.py
+++ b/aplpy/grid.py
@@ -59,7 +59,9 @@ class Grid(object):
         elif np.isreal(xspacing):
             self.x_auto_spacing = False
             if self._wcs.xaxis_coord_type in ['longitude', 'latitude']:
-                self.x_grid_spacing = au.Angle(degrees=xspacing, latitude=self._wcs.xaxis_coord_type == 'latitude')
+                self.x_grid_spacing = au.Angle(
+                    degrees=xspacing,
+                    latitude=self._wcs.xaxis_coord_type == 'latitude')
             else:
                 self.x_grid_spacing = xspacing
         else:
@@ -84,7 +86,9 @@ class Grid(object):
         elif np.isreal(yspacing):
             self.y_auto_spacing = False
             if self._wcs.yaxis_coord_type in ['longitude', 'latitude']:
-                self.y_grid_spacing = au.Angle(degrees=yspacing, latitude=self._wcs.yaxis_coord_type == 'latitude')
+                self.y_grid_spacing = au.Angle(
+                    degrees=yspacing,
+                    latitude=self._wcs.yaxis_coord_type == 'latitude')
             else:
                 self.y_grid_spacing = yspacing
         else:
@@ -164,7 +168,8 @@ class Grid(object):
         # Set x grid spacing
         if self.x_auto_spacing:
             if self.ax.xaxis.apl_auto_tick_spacing:
-                xspacing = default_spacing(self.ax, 'x', self.ax.xaxis.apl_label_form)
+                xspacing = default_spacing(self.ax, 'x',
+                                           self.ax.xaxis.apl_label_form)
             else:
                 xspacing = self.ax.xaxis.apl_tick_spacing
         else:
@@ -180,7 +185,8 @@ class Grid(object):
         # Set y grid spacing
         if self.y_auto_spacing:
             if self.ax.yaxis.apl_auto_tick_spacing:
-                yspacing = default_spacing(self.ax, 'y', self.ax.yaxis.apl_label_form)
+                yspacing = default_spacing(self.ax, 'y',
+                                           self.ax.yaxis.apl_label_form)
             else:
                 yspacing = self.ax.yaxis.apl_tick_spacing
         else:
@@ -256,7 +262,8 @@ class Grid(object):
         # If we are dealing with longitude/latitude then can search all
         # neighboring grid lines to see if there are any closed longitude
         # lines
-        if self._wcs.xaxis_coord_type == 'longitude' and self._wcs.yaxis_coord_type == 'latitude' and len(grid_y_i) > 0:
+        if (self._wcs.xaxis_coord_type == 'longitude' and
+           self._wcs.yaxis_coord_type == 'latitude' and len(grid_y_i) > 0):
 
             gy = grid_y_i.min()
 


### PR DESCRIPTION
This fixes #72. 
I hope I have chosen the right approach to solve this issue: when computing the grid lines, I replace the use of the wcs '"footprint" (0, 0, nx, ny) by the size of the figure axes (`self.ax.xaxis.get_view_interval`). 
I can remove the last commit (pep8 cleaning) if you find it easier to review. 

Example:
https://f.cloud.github.com/assets/311639/513889/8ddd758c-be4a-11e2-9cb6-20b2cd1c9593.jpg
