### PR TITLE
Allow RGB cubes to be specified from arbitrary data, not just .png's and .jpg's

### DIFF
--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -65,7 +65,7 @@ class FITSFigure(Layers, Regions, Deprecated):
     def __init__(self, data, hdu=0, figure=None, subplot=(1, 1, 1),
                  downsample=False, north=False, convention=None,
                  dimensions=[0, 1], slices=[], auto_refresh=None,
-                 **kwargs):
+                 rgb_cube=False, **kwargs):
         '''
         Create a FITSFigure instance.
 
@@ -133,6 +133,11 @@ class FITSFigure(Layers, Regions, Deprecated):
             set_auto_refresh method. This defaults to `True` if and only if
             APLpy is being used from IPython and the Matplotlib backend is
             interactive.
+
+        rgb_cube : bool, optional
+            If set, data will be treated as an RGB cube, with 1st dimension as
+            the rgb or rgba value.  This prevents slicing along other
+            dimensions.
 
         kwargs
             Any additional arguments are passed on to matplotlib's Figure() class.
@@ -213,8 +218,9 @@ class FITSFigure(Layers, Regions, Deprecated):
                 log.warning("north argument is ignored if data passed is a WCS object")
                 north = False
         else:
-            self._data, self._header, self._wcs = self._get_hdu(data, hdu, north, \
-                convention=convention, dimensions=dimensions, slices=slices)
+            self._data, self._header, self._wcs = self._get_hdu(data, hdu,
+                    north, convention=convention, dimensions=dimensions,
+                    slices=slices, rgb_cube=rgb_cube)
             self._wcs.nx = self._header['NAXIS%i' % (dimensions[0] + 1)]
             self._wcs.ny = self._header['NAXIS%i' % (dimensions[1] + 1)]
 
@@ -288,7 +294,8 @@ class FITSFigure(Layers, Regions, Deprecated):
         # Set default theme
         self.set_theme(theme='pretty')
 
-    def _get_hdu(self, data, hdu, north, convention=None, dimensions=[0, 1], slices=[]):
+    def _get_hdu(self, data, hdu, north, convention=None, dimensions=[0, 1],
+            slices=[], rgb_cube=False):
 
         if isinstance(data, six.string_types):
 
@@ -379,13 +386,17 @@ class FITSFigure(Layers, Regions, Deprecated):
                 slices = [0 for i in range(1, len(shape) - 1)]
                 log.info("Setting slices=%s" % str(slices))
 
-        # Extract slices
-        data = slicer.slice_hypercube(data, header, dimensions=dimensions, slices=slices)
+        if not rgb_cube:
+            # Extract slices
+            data = slicer.slice_hypercube(data, header, dimensions=dimensions, slices=slices)
 
         # Check header
         header = header_util.check(header, convention=convention, dimensions=dimensions)
 
         # Parse WCS info
+        if rgb_cube:
+            del header['NAXIS3']
+            header['NAXIS'] = 2
         wcs = wcs_util.WCS(header, dimensions=dimensions, slices=slices, relax=True)
 
         return data, header, wcs
@@ -764,6 +775,11 @@ class FITSFigure(Layers, Regions, Deprecated):
         if filename is None:
             if hasattr(self, '_rgb_image'):
                 image = Image.open(self._rgb_image)
+            elif self._data.ndim == 3 and self._data.shape[0] in (3,4):
+                # allow initialization from a valid cube
+                # (allows rgb, rgba)
+                # FITS and PIL have opposite conventions - but do 0 and 1 need to be swapped too?
+                image = self._data.swapaxes(0,2)
             else:
                 raise Exception("Need to specify the filename of an RGB image")
         else:
@@ -772,10 +788,10 @@ class FITSFigure(Layers, Regions, Deprecated):
         if image_util._matplotlib_pil_bug_present():
             vertical_flip = True
 
-        if vertical_flip:
+        if vertical_flip and isinstance(image,Image.Image):
             image = image.transpose(Image.FLIP_TOP_BOTTOM)
 
-        if horizontal_flip:
+        if horizontal_flip and isinstance(image,Image.Image):
             image = image.transpose(Image.FLIP_LEFT_RIGHT)
 
         # Elsewhere in APLpy we assume that we are using origin='lower' so here

--- a/aplpy/tests/test_rgb.py
+++ b/aplpy/tests/test_rgb.py
@@ -53,4 +53,17 @@ class TestRGB(BaseImageTests):
 
         f.recenter(359.3, -72.1, radius=0.05)
 
+
+
         return f
+
+
+# this test fails because the image is treated as a 3-layer data cube instead of an RGB cube
+# Is there any way to pass in a python object rather than a .png or .jpg for testing RGB data?
+#@pytest.mark.xfail
+def test_rgb():
+    data = np.zeros((3, 16, 16))
+    header = fits.Header.fromtextfile(HEADER)
+    hdu = fits.ImageHDU(data, header=header)
+    f = FITSFigure(hdu, rgb_cube=True)
+    f.show_rgb()


### PR DESCRIPTION
@astrofrog - this is primarily to allow testing for #112, but will be useful in its own right.

In order to allow RGB data cubes to be passed in, right now the headers need to be hacked to ignore `NAXIS3` and some other parameters.  This is far from ideal.  I think the `rgb_cube` flag is necessary, though.

Right now, the sole test passes, but I'm not sure if I have the orientation correct - will have to check that later.
