### PR TITLE
improve docstrings for show_circles

### DIFF
--- a/aplpy/aplpy.py
+++ b/aplpy/aplpy.py
@@ -978,13 +978,16 @@ class FITSFigure(Layers, Regions, Deprecated):
         ----------
 
         xw : list or `~numpy.ndarray`
-            The x postions of the circles (in world coordinates)
+            The x postions of the circles (in world coordinates, 
+            usually degrees)
 
         yw : list or `~numpy.ndarray`
-            The y positions of the circles (in world coordinates)
+            The y positions of the circles (in world coordinates, 
+            usually degrees)
 
         radius : int or float or list or `~numpy.ndarray`
-            The radii of the circles (in world coordinates)
+            The radii of the circles (in world coordinates, usually 
+            arcseconds)
 
         layer : str, optional
             The name of the circle layer. This is useful for giving


### PR DESCRIPTION
Before it said ra, dec, radius "in WCS".
However, radius is multiplied by 3600 a few lines below.
I was stuck on that for a while yesterday, so I suggest to say
"degrees" and "arcseconds".
I don't think that's super important, as I expect that Aplpy will soon take
astropy.quantity objects anyway...
