### PR TITLE
Add ability to specify a WCS when showing an RGB image

### DIFF
--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -191,8 +191,8 @@ class FITSFigure(Layers, Regions):
             data.wcs.crpix = [data.wcs.crpix[0] / nx * float(nx), data.wcs.crpix[1] / ny * float(ny)]
 
             # Update the NAXIS values with the true dimensions of the RGB image
-            data.wcs.naxis1 = data.nx = nx
-            data.wcs.naxis2 = data.ny = ny
+            data._naxis1 = data.nx = nx
+            data._naxis2 = data.ny = ny
 
         if isinstance(data, WCS):
 


### PR DESCRIPTION
When doing `show_rgb`, a `wcs` may be specified that is used for the image so that overlays can be created.

Unfortunately, `mpl`'s `pcolormesh` doesn't seem to allow RGB inputs, so this can only be done with imshow and therefore with no distortion allowed.  This limitation means you can't use this for very large-scale views where projection matters.

I also don't think I've taken proper care of recording layers... once you add this layer, it can't be removed at the moment.  @astrofrog, how should I do that?  Just add a new `'image_layer_#'`?

Here's a somewhat ugly first attempt showing how it can be useful: this is an RGBA image where `A<1`

![sample_rgb_overlay](https://f.cloud.github.com/assets/143715/1715487/b5998590-61b3-11e3-90c0-86d3dbf33361.png)

p.s. sorry about the whitespace reformatting in imshow... I can undo that if it's too annoying
