### PR TITLE
show_contour() plots the FITSFigure image

### DIFF
--- a/aplpy/aplpy.py
+++ b/aplpy/aplpy.py
@@ -791,7 +791,7 @@ class FITSFigure(Layers, Regions, Deprecated):
         self.image = self._ax1.imshow(image, extent=self._extent, interpolation=interpolation, origin='upper')
 
     @auto_refresh
-    def show_contour(self, data, hdu=0, layer=None, levels=5, filled=False, cmap=None, colors=None, returnlevels=False, convention=None, dimensions=[0, 1], slices=[], smooth=None, kernel='gauss', overlap=False, **kwargs):
+    def show_contour(self, data=None, hdu=0, layer=None, levels=5, filled=False, cmap=None, colors=None, returnlevels=False, convention=None, dimensions=[0, 1], slices=[], smooth=None, kernel='gauss', overlap=False, **kwargs):
         '''
         Overlay contours on the current plot.
 
@@ -888,8 +888,15 @@ class FITSFigure(Layers, Regions, Deprecated):
         elif not colors:
             cmap = mpl.cm.get_cmap('jet')
 
-        data_contour, header_contour, wcs_contour = self._get_hdu(data, hdu, False, \
-            convention=convention, dimensions=dimensions, slices=slices)
+        if data:
+            data_contour, header_contour, wcs_contour = self._get_hdu(data, \
+                    hdu, False, convention=convention, dimensions=dimensions, \
+                    slices=slices)
+        else:
+            data_contour = self._data
+            header_contour = self._header
+            wcs_contour = self._wcs
+
         wcs_contour.nx = header_contour['NAXIS%i' % (dimensions[0] + 1)]
         wcs_contour.ny = header_contour['NAXIS%i' % (dimensions[1] + 1)]
 


### PR DESCRIPTION
I ran into a situation where memory issues dictated being able to have show_contour() use the image from FITSFigure, as described in Issue #123. That is,

```

f = FITSFigure('image.fits')
f.show_contour()
```

produces a contour plot in the way that currently would be achieved with

```

f = FITSFigure('image.fits')
f.show_contour('image.fits')
```

The following example

```

f = FITSFigure('image1.fits')
f.show_contour('image2.fits')
```

works in the same way that show_contour() currently works. I've tested it out in a handful of different scenarios where I've used show_contour() in the past, and I have not encountered any problems. 
