### PR TITLE
show_colorscale does not accept the "smooth" parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ CHANGES
 0.9.14 (unreleased)
 -------------------
 
-    - No changes yet
+    Bug fixes
+    ~~~~~~~~~
+
+    - Fix a bug that caused smoothing to fail with integer arrays. [#165]
 
 0.9.13 (2014-10-04)
 -------------------

--- a/aplpy/convolve_util.py
+++ b/aplpy/convolve_util.py
@@ -21,7 +21,7 @@ def convolve(image, smooth=3, kernel='gauss'):
     # The Astropy convolution doesn't treat +/-Inf values correctly yet, so we
     # convert to NaN here.
 
-    image_fixed = image.copy()
+    image_fixed = np.array(image, dtype=float, copy=True)
     image_fixed[np.isinf(image)] = np.nan
 
     if kernel == 'gauss':

--- a/aplpy/tests/test_convolve.py
+++ b/aplpy/tests/test_convolve.py
@@ -43,3 +43,11 @@ def test_convolve_custom():
     f.show_grayscale(kernel=np.ones((3,3)))
     f.close()
 
+
+def test_convolve_default():
+    # Regression test for aplpy/aplpy#165
+    data = np.ones((16, 16), dtype=int)
+    hdu = fits.PrimaryHDU(data)
+    f = FITSFigure(hdu)
+    f.show_grayscale(smooth=3)
+    f.close()


### PR DESCRIPTION
I updated some package within python or aplpy or whatever (I really do not remember what was it exactly) but now when I want to produce a skymap from a fits file using the show_colorscale function I cannot select a smoothing parameter. My script is called plot_maps.py. I am using the Anaconda python distribution and it works perfect except for that.

the command that I pass in my script is:

f3.show_colorscale(vmin=0.68, vmax=1.8, smooth=3., kernel='gauss', interpolation='bicubic')

Without the smooth=3.0 option it works perfect (but I need the image to be smoothed).

The error I get is the following:

```
Traceback (most recent call last):
File "plot_maps.py", line 123, in 
f3.show_colorscale(vmin=0.68, vmax=1.8, smooth=3., kernel='gauss', interpolation='bicubic')
File "", line 2, in show_colorscale
File "/home/gamma/radix/pmunar/bin/anaconda/lib/python2.7/site-packages/aplpy/decorators.py", line 25, in autorefresh
f(args, *kwargs)
File "/home/gamma/radix/pmunar/bin/anaconda/lib/python2.7/site-packages/aplpy/aplpy.py", line 709, in show_colorscale
self.image = self.ax1.imshow(convolveutil.convolve(self.data, smooth=smooth, kernel=kernel), cmap=cmap, interpolation=interpolation, origin='lower', extent=self.extent, norm=normalizer, aspect=aspect)
File "/home/gamma/radix/pmunar/bin/anaconda/lib/python2.7/site-packages/aplpy/convolve_util.py", line 25, in convolve
image_fixed[np.isinf(image)] = np.nan
ValueError: cannot convert float NaN to integer
```

Thank you for your help
