### PR TITLE
Update APLpy to avoid deprecation warnings in Astropy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ CHANGES
 
     - Fix a bug that caused smoothing to fail with integer arrays. [#165]
 
+    Improvements
+    ~~~~~~~~~~~~
+
+    - Fix deprecation warnings from Astropy. [#173]
+
 0.9.13 (2014-10-04)
 -------------------
 

--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -233,8 +233,8 @@ class FITSFigure(Layers, Regions, Deprecated):
             if wcs.naxis != 2:
                 raise ValueError("FITSFigure initialization via WCS objects can only be done with 2-dimensional WCS objects")
             header = wcs.to_header()
-            header.update('NAXIS1', wcs.naxis1)
-            header.update('NAXIS2', wcs.naxis2)
+            header['NAXIS1'] = wcs.naxis1
+            header['NAXIS2'] = wcs.naxis2
             nx = header['NAXIS%i' % (dimensions[0] + 1)]
             ny = header['NAXIS%i' % (dimensions[1] + 1)]
             self._data = np.zeros((ny, nx), dtype=float)

--- a/aplpy/header.py
+++ b/aplpy/header.py
@@ -12,14 +12,14 @@ def check(header, convention=None, dimensions=[0, 1]):
     # missing or incomplete, and replace it with a 1-to-1 pixel mapping
     if 'CTYPE%i' % ix not in header or 'CTYPE%i' % iy not in header:
         log.warning("No WCS information found in header - using pixel coordinates")
-        header.update('CTYPE%i' % ix, 'PIXEL')
-        header.update('CTYPE%i' % iy, 'PIXEL')
-        header.update('CRVAL%i' % ix, 0.)
-        header.update('CRVAL%i' % iy, 0.)
-        header.update('CRPIX%i' % ix, 0.)
-        header.update('CRPIX%i' % iy, 0.)
-        header.update('CDELT%i' % ix, 1.)
-        header.update('CDELT%i' % iy, 1.)
+        header['CTYPE%i' % ix] = 'PIXEL'
+        header['CTYPE%i' % iy] = 'PIXEL'
+        header['CRVAL%i' % ix] = 0.
+        header['CRVAL%i' % iy] = 0.
+        header['CRPIX%i' % ix] = 0.
+        header['CRPIX%i' % iy] = 0.
+        header['CDELT%i' % ix] = 1.
+        header['CDELT%i' % iy] = 1.
 
     if header['CTYPE%i' % ix][4:] == '-CAR' and header['CTYPE%i' % iy][4:] == '-CAR':
 


### PR DESCRIPTION
Now that deprecation warnings are visible in Astropy, it's time to update APLpy to make sure we're using the latest API from Astropy!
