### PR TITLE
Use PACKAGENAME everywhere for name of package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ for root, dirs, files in os.walk(PACKAGENAME):
                     os.path.relpath(root, PACKAGENAME), filename))
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
-setup(name='APLpy',
+setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,


### PR DESCRIPTION
@astrofrog -- this PR allows aplpy to be built with `bdist_conda`. I assume this doesn't break anything pypi related, but haven't checked...

This eliminates one place where the name of the package was mixed case.