### PR TITLE
Rasterize contours

### DIFF
--- a/aplpy/contour_util.py
+++ b/aplpy/contour_util.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, print_function, division
 
 import numpy as np
 from matplotlib.path import Path
+from matplotlib.collections import Collection
+from matplotlib.artist import allow_rasterization
 
 from . import wcs_util
 
@@ -43,3 +45,29 @@ def transform(contours, wcs_in, wcs_out, filled=False, overlap=False):
             contour.set_verts(polygons_out)
 
         contour.apl_converted = True
+
+
+class ListCollection(Collection):
+    def __init__(self, collections, **kwargs):
+        Collection.__init__(self, **kwargs)
+        self.set_collections(collections)
+
+    def set_collections(self, collections):
+        self._collections = collections
+
+    def get_collections(self):
+        return self._collections
+
+    @allow_rasterization
+    def draw(self, renderer):
+        for _c in self._collections:
+            _c.draw(renderer)
+
+
+def insert_rasterized_contour_plot(c, ax):
+    collections = c.collections
+    for _c in collections:
+        _c.remove()
+    cc = ListCollection(collections, rasterized=True)
+    ax.add_artist(cc)
+    return cc

--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -900,11 +900,16 @@ class FITSFigure(Layers, Regions, Deprecated):
             specify if they would prefer 'gauss', 'box', or a custom
             kernel. All kernels are normalized to ensure flux retention.
 
-        overlap str, optional
+        overlap : str, optional
             Whether to include only contours that overlap with the image
             area. This significantly speeds up the drawing of contours and
             reduces file size when using a file for the contours covering
             a much larger area than the image.
+
+        rasterize : bool, optional
+            Rasterizes the contour set. This is drastically decreases the
+            file size when saving as a vector graphic at the expense of
+            saving the contour as a vector itself.
 
         kwargs
             Additional keyword arguments (such as alpha, linewidths, or

--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -907,7 +907,7 @@ class FITSFigure(Layers, Regions, Deprecated):
             a much larger area than the image.
 
         rasterize : bool, optional
-            Rasterizes the contour set. This is drastically decreases the
+            Rasterizes the contour set. This drastically decreases the
             file size when saving as a vector graphic at the expense of
             saving the contour as a vector itself.
 

--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -78,6 +78,7 @@ from .regions import Regions
 from .colorbar import Colorbar
 from .normalize import APLpyNormalize
 from .frame import Frame
+from .contour_util import insert_rasterized_contour_plot
 
 from .decorators import auto_refresh, fixdocstring
 
@@ -822,7 +823,10 @@ class FITSFigure(Layers, Regions, Deprecated):
         self.image = self._ax1.imshow(image, extent=self._extent, interpolation=interpolation, origin='lower')
 
     @auto_refresh
-    def show_contour(self, data=None, hdu=0, layer=None, levels=5, filled=False, cmap=None, colors=None, returnlevels=False, convention=None, dimensions=[0, 1], slices=[], smooth=None, kernel='gauss', overlap=False, **kwargs):
+    def show_contour(self, data=None, hdu=0, layer=None, levels=5,
+                     filled=False, cmap=None, colors=None, returnlevels=False,
+                     convention=None, dimensions=[0, 1], slices=[], smooth=None,
+                     kernel='gauss', overlap=False, rasterize=False, **kwargs):
         '''
         Overlay contours on the current plot.
 
@@ -944,6 +948,9 @@ class FITSFigure(Layers, Regions, Deprecated):
             c = self._ax1.contourf(image_contour, levels, extent=extent_contour, cmap=cmap, colors=colors, **kwargs)
         else:
             c = self._ax1.contour(image_contour, levels, extent=extent_contour, cmap=cmap, colors=colors, **kwargs)
+
+        if rasterize:
+            insert_rasterized_contour_plot(c, self._ax1)
 
         if layer:
             contour_set_name = layer


### PR DESCRIPTION
Uses the example from [this SO answer](http://stackoverflow.com/questions/12583970/matplotlib-contour-plots-as-postscript/12804395#12804395) to rasterize the contours.

I have been creating figures with multiple, large contour sets which end up with a file size around 50-100 Mb when saved as a PDF. Rasterizing them shrinks this to ~1 Mb. For my purposes, extensive zooming isn't much of a concern.