### PR TITLE
Created astropy.wcs.wcs.WCS object out of self._header

### DIFF
--- a/aplpy/regions.py
+++ b/aplpy/regions.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 from astropy.extern import six
 from astropy import log
+from astropy import wcs
 
 from .decorators import auto_refresh
 
@@ -61,7 +62,7 @@ class Regions:
             ds9 call and onto the patchcollections.
         """
 
-        PC, TC = ds9(region_file, self._header, **kwargs)
+        PC, TC = ds9(region_file, wcs.WCS(self._header).sub([wcs.WCSSUB_CELESTIAL]), **kwargs)
 
         # ffpc = self._ax1.add_collection(PC)
         PC.add_to_axes(self._ax1)


### PR DESCRIPTION
I was getting this error message when I tried ```fig.show_regions(region_list)``` where ```region_list``` is a pyregion ShapeList or ```fig.show_regions('regions.reg')```.  I figured out a solution that works on my machine. 

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-372-c7aa93ef5953> in <module>()
----> 1 fig.show_regions(region_list)

/Users/alyo7318/anaconda/anaconda/lib/python2.7/site-packages/aplpy/regions.pyc in show_regions(self, region_file, layer, **kwargs)

/Users/alyo7318/anaconda/anaconda/lib/python2.7/site-packages/aplpy/decorators.pyc in _auto_refresh(f, *args, **kwargs)
     23     mydata.nesting = getattr(mydata, 'nesting', 0) + 1
     24     try:
---> 25         return f(*args, **kwargs)
     26     finally:
     27         mydata.nesting -= 1

/Users/alyo7318/anaconda/anaconda/lib/python2.7/site-packages/aplpy/regions.pyc in show_regions(self, region_file, layer, **kwargs)
     62         #"""
     63 
---> 64         PC, TC = ds9(region_file, self._header, **kwargs)
     65 
     66         # ffpc = self._ax1.add_collection(PC)

/Users/alyo7318/anaconda/anaconda/lib/python2.7/site-packages/aplpy/regions.pyc in ds9(region_file, header, zorder, **kwargs)
    100 
    101     # convert coordinates to image coordinates
--> 102     rrim = rr.as_imagecoord(header)
    103 
    104     # pyregion and aplpy both correct for the FITS standard origin=1,1

/Users/alyo7318/anaconda/anaconda/lib/python2.7/site-packages/pyregion/__init__.pyc in as_imagecoord(self, header, rot_wrt_axis)
     55         r = RegionParser.sky_to_image(zip(self, comment_list),
     56                                       header, rot_wrt_axis=rot_wrt_axis)
---> 57         shape_list, comment_list = zip(*list(r))
     58         return ShapeList(shape_list, comment_list=comment_list)
     59 

/Users/alyo7318/anaconda/anaconda/lib/python2.7/site-packages/pyregion/ds9_region_parser.pyc in sky_to_image(l, header, rot_wrt_axis)
    182             if isinstance(l1, Shape) and \
    183                    (l1.coord_format not in image_like_coordformats):
--> 184                 tgt = wcs_proj.radesys
    185                 if l1.coord_format == UnknownWcs:
    186                     src = tgt

/Users/alyo7318/anaconda/anaconda/lib/python2.7/site-packages/pyregion/wcs_helper.pyc in _get_radesys(self)
    228 
    229     def _get_radesys(self):
--> 230         ctype1, ctype2 = self.ctypes
    231         equinox = self.equinox
    232         radecsys = coord_system_guess(ctype1, ctype2, equinox)

ValueError: too many values to unpack
```