### PR TITLE
Tweak to tick label positioning  - h:m: on left side, not right

### DIFF
--- a/aplpy/labels.py
+++ b/aplpy/labels.py
@@ -324,11 +324,11 @@ class TickLabels(object):
             The position to show the dd:mm part of the label
         """
         if position == 'top':
-            self._ax1.get_major_formatter().full_coordinate_string = 'end'
-            self._ax2.get_major_formatter().full_coordinate_string = 'end'
+            self._ax1.yaxis.get_major_formatter().full_coordinate_string = 'end'
+            self._ax2.yaxis.get_major_formatter().full_coordinate_string = 'end'
         elif position == 'bottom':
-            self._ax1.get_major_formatter().full_coordinate_string = 'start'
-            self._ax2.get_major_formatter().full_coordinate_string = 'start'
+            self._ax1.yaxis.get_major_formatter().full_coordinate_string = 'start'
+            self._ax2.yaxis.get_major_formatter().full_coordinate_string = 'start'
         else:
             raise ValueError("position should be one of 'top' or 'bottom'")
 
@@ -345,11 +345,11 @@ class TickLabels(object):
             The position to show the hh:mm part of the label
         """
         if position == 'right':
-            self._ax1.get_major_formatter().full_coordinate_string = 'end'
-            self._ax2.get_major_formatter().full_coordinate_string = 'end'
+            self._ax1.xaxis.get_major_formatter().full_coordinate_string = 'end'
+            self._ax2.xaxis.get_major_formatter().full_coordinate_string = 'end'
         elif position == 'left':
-            self._ax1.get_major_formatter().full_coordinate_string = 'start'
-            self._ax2.get_major_formatter().full_coordinate_string = 'start'
+            self._ax1.xaxis.get_major_formatter().full_coordinate_string = 'start'
+            self._ax2.xaxis.get_major_formatter().full_coordinate_string = 'start'
         else:
             raise ValueError("position should be one of 'left' or 'right'")
 

--- a/aplpy/labels.py
+++ b/aplpy/labels.py
@@ -429,10 +429,16 @@ class WCSFormatter(mpl.Formatter):
 
             if len(label) > 1:
 
-                if self.coord == x or self.axis.apl_tick_positions_world[ipos] > 0:
-                    comp_ipos = ipos - 1
+                if self.coord_type == 'longitude':
+                    # longitude increases the other direction....
+                    sign = -1
                 else:
-                    comp_ipos = ipos + 1
+                    sign = 1
+
+                if self.coord == x or self.axis.apl_tick_positions_world[ipos] > 0:
+                    comp_ipos = ipos - sign
+                else:
+                    comp_ipos = ipos + sign
 
                 if comp_ipos >= 0 and comp_ipos <= len(self.axis.apl_tick_positions_pix) - 1:
 

--- a/aplpy/labels.py
+++ b/aplpy/labels.py
@@ -311,6 +311,48 @@ class TickLabels(object):
         else:
             raise ValueError("position should be one of 'left' or 'right'")
 
+    @auto_refresh
+    def set_y_full_label_side(self, position):
+        """
+        For labels of the form dd:mm:ss.ss, most of the ticks will show only
+        the ss.ss part.  The dd:mm component will be shown only once, either
+        at the top or bottom.
+
+        Parameters
+        ----------
+        position : 'top' or 'bottom'
+            The position to show the dd:mm part of the label
+        """
+        if position == 'top':
+            self._ax1.get_major_formatter().full_coordinate_string = 'end'
+            self._ax2.get_major_formatter().full_coordinate_string = 'end'
+        elif position == 'bottom':
+            self._ax1.get_major_formatter().full_coordinate_string = 'start'
+            self._ax2.get_major_formatter().full_coordinate_string = 'start'
+        else:
+            raise ValueError("position should be one of 'top' or 'bottom'")
+
+    @auto_refresh
+    def set_x_full_label_side(self, position):
+        """
+        For labels of the form hh:mm:ss.ss, most of the ticks will show only
+        the ss.ss part.  The hh:mm component will be shown only once, either
+        at the left or right.
+
+        Parameters
+        ----------
+        position : 'left' or 'right'
+            The position to show the hh:mm part of the label
+        """
+        if position == 'right':
+            self._ax1.get_major_formatter().full_coordinate_string = 'end'
+            self._ax2.get_major_formatter().full_coordinate_string = 'end'
+        elif position == 'left':
+            self._ax1.get_major_formatter().full_coordinate_string = 'start'
+            self._ax2.get_major_formatter().full_coordinate_string = 'start'
+        else:
+            raise ValueError("position should be one of 'left' or 'right'")
+
     def _set_cursor_prefs(self, event, **kwargs):
         if event.key == 'c':
             self._ax1._cursor_world = not self._ax1._cursor_world
@@ -379,9 +421,19 @@ class TickLabels(object):
 
 class WCSFormatter(mpl.Formatter):
 
-    def __init__(self, wcs=False, coord='x'):
+    def __init__(self, wcs=False, coord='x', full_coordinate_string='end'):
+        """
+        Parameters
+        ----------
+        full_coordinate_string : 'start' or 'end'
+            Determines where the full string (hh:mm:ss.ss) should be: at the
+            start or end of the row/column.  For vertical, start=bottom,
+            end=top.  For horizontal, start=left, end=right.
+
+        """
         self._wcs = wcs
         self.coord = coord
+        self.full_coordinate_string = full_coordinate_string
 
     def __call__(self, x, pos=None):
         """
@@ -429,11 +481,13 @@ class WCSFormatter(mpl.Formatter):
 
             if len(label) > 1:
 
-                if self.coord_type == 'longitude':
+                if self.full_coordinate_string == 'end':
                     # longitude increases the other direction....
                     sign = -1
-                else:
+                elif self.full_coordinate_string == 'start':
                     sign = 1
+                else:
+                    raise ValueError("full_coordinate_string must be 'start' or 'end'")
 
                 if self.coord == x or self.axis.apl_tick_positions_world[ipos] > 0:
                     comp_ipos = ipos - sign

--- a/aplpy/labels.py
+++ b/aplpy/labels.py
@@ -344,10 +344,10 @@ class TickLabels(object):
         position : 'left' or 'right'
             The position to show the hh:mm part of the label
         """
-        if position == 'right':
+        if position == 'left':
             self._ax1.xaxis.get_major_formatter().full_coordinate_string = 'end'
             self._ax2.xaxis.get_major_formatter().full_coordinate_string = 'end'
-        elif position == 'left':
+        elif position == 'right':
             self._ax1.xaxis.get_major_formatter().full_coordinate_string = 'start'
             self._ax2.xaxis.get_major_formatter().full_coordinate_string = 'start'
         else:


### PR DESCRIPTION
Should solve https://github.com/aplpy/aplpy/issues/258, e.g.:

![image](https://cloud.githubusercontent.com/assets/143715/9387893/e5bc7b88-4762-11e5-8592-f0d21390f11f.png)
