### PR TITLE
Scalebar bugfix

### DIFF
--- a/aplpy/overlays.py
+++ b/aplpy/overlays.py
@@ -359,9 +359,14 @@ class Scalebar(object):
         All arguments are passed to the matplotlib Text class. See the
         matplotlib documentation for more details.
         '''
-        for kwarg in kwargs:
-            self._label_settings[kwarg] = kwargs[kwarg]
-        self._scalebar.txt_label.get_children()[0].set(**kwargs)
+        for kwarg,val in kwargs.items():
+            try:
+                # Only set attributes that exist
+                kvpair = {kwarg:val}
+                self._scalebar.txt_label.get_children()[0].set(**kvpair)
+                self._label_settings[kwarg] = val
+            except AttributeError:
+                warnings.warn("Text labels do not have attribute {0}.  Skipping.".format(kwarg))
 
     @auto_refresh
     def _set_scalebar_properties(self, **kwargs):
@@ -371,9 +376,13 @@ class Scalebar(object):
         All arguments are passed to the matplotlib Rectangle class. See the
         matplotlib documentation for more details.
         '''
-        for kwarg in kwargs:
-            self._scalebar_settings[kwarg] = kwargs[kwarg]
-        self._scalebar.size_bar.get_children()[0].set(**kwargs)
+        for kwarg,val in kwargs.items():
+            try:
+                kvpair = {kwarg:val}
+                self._scalebar_settings[kwarg] = val
+                self._scalebar.size_bar.get_children()[0].set(**kvpair)
+            except AttributeError:
+                warnings.warn("Scalebar does not have attribute {0}.  Skipping.".format(kwarg))
 
     @auto_refresh
     def set(self, **kwargs):


### PR DESCRIPTION
Doing the following:
```
F.scalebar.set_linewidth(5)
F.scalebar.set_length(100)
```

results in an error like:
```
  File "/Users/adam/repos/aplpy/aplpy/overlays.py", line 245, in set_length
    self._set_label_properties(**self._scalebar_settings)
  File "<string>", line 2, in _set_label_properties
  File "/Users/adam/repos/aplpy/aplpy/decorators.py", line 25, in _auto_refresh
    return f(*args, **kwargs)
  File "/Users/adam/repos/aplpy/aplpy/overlays.py", line 364, in _set_label_properties
    self._scalebar.txt_label.get_children()[0].set(**kwargs)
  File "/Users/adam/anaconda/envs/astropy27/lib/python2.7/site-packages/matplotlib/artist.py", line 827, in set
    func = getattr(self, funcName)
AttributeError: 'Text' object has no attribute 'set_linewidth'
```