### PR TITLE
Fixing miniconda path in .travis.xml and updating helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,11 +60,15 @@ before_install:
     # Use utf8 encoding. Should be default, but this is insurance against
     # future changes
     - export PYTHONIOENCODING=UTF8
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
+
+    # http://conda.pydata.org/docs/travis.html#the-travis-yml-file
+    - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a
 
     # DOCUMENTATION DEPENDENCIES
     - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,17 @@
 language: python
 
+# Setting sudo to false opts in to Travis-CI container-based builds.
+sudo: false
+
+# The apt packages below are needed for sphinx builds, which can no longer
+# be installed with sudo apt-get.
+addons:
+    apt:
+        packages:
+            - graphviz
+            - texlive-latex-extra
+            - dvipng
+
 python:
     - 2.6
     - 2.7
@@ -69,9 +81,6 @@ before_install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda info -a
-
-    # DOCUMENTATION DEPENDENCIES
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
 
     # Make sure that interactive matplotlib backends work
     - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,18 +33,14 @@ env:
 matrix:
     include:
 
-        # Do a coverage test in Python 2.
-        - python: 2.7
-          env: ASTROPY_VERSION=development SETUP_CMD='test --coverage'
-
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
 
-        # Try Astropy development and LTS version
+        # Try Astropy development and LTS version and also a coverage test
         - python: 2.7
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
+          env: ASTROPY_VERSION=development SETUP_CMD='test --coverage'
         - python: 3.5
           env: ASTROPY_VERSION=development SETUP_CMD='test'
         - python: 2.7
@@ -53,6 +49,8 @@ matrix:
           env: ASTROPY_VERSION=lts SETUP_CMD='test'
 
         # Try all python versions with the latest numpy
+        - python: 2.6
+          env: SETUP_CMD='test --remote-data' NUMPY_VERSION=1.9
         - python: 3.3
           env: SETUP_CMD='test --remote-data' NUMPY_VERSION=1.9
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
-        - MATPLOTLIB_VERSION=1.4
+        - MATPLOTLIB_VERSION=1.4.*
         - CONDA_DEPENDENCIES='nose pyqt matplotlib pillow'
 
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: python
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
-# The apt packages below are needed for sphinx builds, which can no longer
-# be installed with sudo apt-get.
+# The apt packages below are needed for sphinx builds
 addons:
     apt:
         packages:
@@ -17,7 +16,7 @@ python:
     - 2.7
     - 3.3
     - 3.4
-    # This is just for "egg_info".  All other builds are explicitly given in the matrix
+
 env:
     global:
         # The following versions are the 'default' for tests, unless
@@ -26,17 +25,16 @@ env:
         - NUMPY_VERSION=1.9
         - ASTROPY_VERSION=stable
         - MATPLOTLIB_VERSION=1.4
-        - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
-        - PIP_INSTALL='pip install'
+        - CONDA_DEPENDENCIES='nose pyqt matplotlib pillow'
+
     matrix:
         - SETUP_CMD='egg_info'
+        - SETUP_CMD='test'
 
 matrix:
     include:
 
-        # Do a coverage test in Python 2. This requires the latest
-        # development version of Astropy, which fixes some issues with
-        # coverage testing in affiliated packages.
+        # Do a coverage test in Python 2.
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='test --coverage'
 
@@ -51,16 +49,6 @@ matrix:
         - python: 3.3
           env: ASTROPY_VERSION=development SETUP_CMD='test'
 
-        # Try all python versions with the latest numpy
-        - python: 2.6
-          env: SETUP_CMD='test'
-        - python: 2.7
-          env: SETUP_CMD='test'
-        - python: 3.3
-          env: SETUP_CMD='test'
-        - python: 3.4
-          env: SETUP_CMD='test'
-
         # Try older numpy versions
         - python: 2.7
           env: NUMPY_VERSION=1.7 SETUP_CMD='test' MATPLOTLIB_VERSION=1.2
@@ -68,19 +56,6 @@ matrix:
           env: NUMPY_VERSION=1.6 SETUP_CMD='test' MATPLOTLIB_VERSION=1.1
 
 before_install:
-
-    # Use utf8 encoding. Should be default, but this is insurance against
-    # future changes
-    - export PYTHONIOENCODING=UTF8
-
-    # http://conda.pydata.org/docs/travis.html#the-travis-yml-file
-    - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    - conda info -a
 
     # Make sure that interactive matplotlib backends work
     - export DISPLAY=:99.0
@@ -90,35 +65,8 @@ before_install:
     - export QT_API=pyqt
 
 install:
-
-    # CONDA
-    - conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
-    - source activate test
-
-    # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
-
-    # ASTROPY
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
-
-    # OPTIONAL DEPENDENCIES
-    # Here you can add any dependencies your package may have. You can use
-    # conda for packages available through conda, or pip for any other
-    # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda`
-    # install since this ensures Numpy does not get automatically upgraded.
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION nose pyqt matplotlib=$MATPLOTLIB_VERSION; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pillow ; fi
-
-    # DOCUMENTATION DEPENDENCIES
-    # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
-    # this matplotlib will *not* work with py 3.x, but our sphinx build is
-    # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
-
-    # COVERAGE DEPENDENCIES
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
+    - git clone git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
 
 script:
    - python setup.py $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,16 @@ addons:
             - dvipng
 
 python:
-    - 2.6
     - 2.7
-    - 3.3
     - 3.4
+    - 3.5
 
 env:
     global:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.9
+        - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - MATPLOTLIB_VERSION=1.4
         - CONDA_DEPENDENCIES='nose pyqt matplotlib pillow'
@@ -43,17 +42,29 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
 
-        # Try Astropy development version
+        # Try Astropy development and LTS version
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='test'
-        - python: 3.3
+        - python: 3.5
           env: ASTROPY_VERSION=development SETUP_CMD='test'
+        - python: 2.7
+          env: ASTROPY_VERSION=lts SETUP_CMD='test'
+        - python: 3.5
+          env: ASTROPY_VERSION=lts SETUP_CMD='test'
+
+        # Try all python versions with the latest numpy
+        - python: 3.3
+          env: SETUP_CMD='test --remote-data' NUMPY_VERSION=1.9
 
         # Try older numpy versions
         - python: 2.7
-          env: NUMPY_VERSION=1.7 SETUP_CMD='test' MATPLOTLIB_VERSION=1.2
+          env: NUMPY_VERSION=1.9 SETUP_CMD='test'
         - python: 2.7
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test' MATPLOTLIB_VERSION=1.1
+          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
+        - python: 2.7
+          env: NUMPY_VERSION=1.7 SETUP_CMD='test'
+        - python: 2.7
+          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
 
 before_install:
 

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -282,6 +282,19 @@ class _Bootstrapper(object):
         strategies = ['local_directory', 'local_file', 'index']
         dist = None
 
+        # First, remove any previously imported versions of astropy_helpers;
+        # this is necessary for nested installs where one package's installer
+        # is installing another package via setuptools.sandbox.run_setup, as in
+        # the case of setup_requires
+        for key in list(sys.modules):
+            try:
+                if key == PACKAGE_NAME or key.startswith(PACKAGE_NAME + '.'):
+                    del sys.modules[key]
+            except AttributeError:
+                # Sometimes mysterious non-string things can turn up in
+                # sys.modules
+                continue
+
         # Check to see if the path is a submodule
         self.is_submodule = self._check_submodule()
 
@@ -310,19 +323,6 @@ class _Bootstrapper(object):
         # do it again
         # Note: Adding the dist to the global working set also activates it
         # (makes it importable on sys.path) by default.
-
-        # But first, remove any previously imported versions of
-        # astropy_helpers; this is necessary for nested installs where one
-        # package's installer is installing another package via
-        # setuptools.sandbox.run_set, as in the case of setup_requires
-        for key in list(sys.modules):
-            try:
-                if key == PACKAGE_NAME or key.startswith(PACKAGE_NAME + '.'):
-                    del sys.modules[key]
-            except AttributeError:
-                # Sometimes mysterious non-string things can turn up in
-                # sys.modules
-                continue
 
         try:
             pkg_resources.working_set.add(dist, replace=True)
@@ -409,7 +409,7 @@ class _Bootstrapper(object):
     def get_index_dist(self):
         if not self.download:
             log.warn('Downloading {0!r} disabled.'.format(DIST_NAME))
-            return False
+            return None
 
         log.warn(
             "Downloading {0!r}; run setup.py with the --offline option to "

--- a/aplpy/conftest.py
+++ b/aplpy/conftest.py
@@ -5,18 +5,40 @@
 from astropy.tests.pytest_plugins import *
 from astropy.tests.pytest_plugins import pytest_addoption as astropy_pytest_addoption
 
+# This is to figure out APLpy version, rather than using Astropy's
+from . import version
+
+try:
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = version.version
+except NameError:
+    pass
+
 # Uncomment the following line to treat all DeprecationWarnings as
 # exceptions
 enable_deprecations_as_exceptions()
 
-import os
 from astropy.tests.helper import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption('--generate-images-path', help="directory to generate reference images in", action='store')
+    parser.addoption('--generate-images-path',
+                     help="directory to generate reference images in",
+                     action='store')
     return astropy_pytest_addoption(parser)
+
 
 @pytest.fixture
 def generate(request):
     return request.config.getoption("--generate-images-path")
+
+# Add astropy to test header information and remove unused packages.
+
+try:
+    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES['pyregion'] = 'pyregion'
+    PYTEST_HEADER_MODULES['PyAVM'] = 'PyAVM'
+    PYTEST_HEADER_MODULES['montage-wrapper'] = 'montage-wrapper'
+    del PYTEST_HEADER_MODULES['h5py']
+except NameError:
+    pass


### PR DESCRIPTION
Miniconda's default prefix changed recently causing all travis builds failing.

And while I was at it I've updated the helpers to the latest one and opted in container based travis.

Also customised the testing header to contain the optional dependencies, and aplpy's version.
