### PR TITLE
Minor frequency

### DIFF
--- a/aplpy/ticks.py
+++ b/aplpy/ticks.py
@@ -206,15 +206,21 @@ class Ticks(object):
             line.set_mew(linewidth)
 
     @auto_refresh
-    def set_minor_frequency(self, frequency):
+    def set_minor_frequency(self, frequency, frequency_y=None):
         '''
         Set the number of subticks per major tick. Set to one to hide minor
         ticks.
+        If not frequency_y given, frequency is the same in both axis.
+        Otherwise, frequency represents the frequency in the xaxis and
+        frequency_y the one in the yaxis.
         '''
+        if frequency_y is None:
+            frequency_y = frequency
+
         self._ax1.xaxis.get_minor_locator().subticks = frequency
-        self._ax1.yaxis.get_minor_locator().subticks = frequency
+        self._ax1.yaxis.get_minor_locator().subticks = frequency_y
         self._ax2.xaxis.get_minor_locator().subticks = frequency
-        self._ax2.yaxis.get_minor_locator().subticks = frequency
+        self._ax2.yaxis.get_minor_locator().subticks = frequency_y
 
     @auto_refresh
     def show(self):

--- a/aplpy/ticks.py
+++ b/aplpy/ticks.py
@@ -206,21 +206,21 @@ class Ticks(object):
             line.set_mew(linewidth)
 
     @auto_refresh
-    def set_minor_frequency(self, frequency, frequency_y=None):
+    def set_minor_frequency(self, xfrequency, yfrequency=None):
         '''
         Set the number of subticks per major tick. Set to one to hide minor
         ticks.
-        If not frequency_y given, frequency is the same in both axis.
-        Otherwise, frequency represents the frequency in the xaxis and
-        frequency_y the one in the yaxis.
+        If not yfrequency given, frequency is the same in both axis.
+        Otherwise, xfrequency represents the frequency in the xaxis and
+        yfrequency the one in the yaxis.
         '''
-        if frequency_y is None:
-            frequency_y = frequency
+        if yfrequency is None:
+            yfrequency = xfrequency
 
-        self._ax1.xaxis.get_minor_locator().subticks = frequency
-        self._ax1.yaxis.get_minor_locator().subticks = frequency_y
-        self._ax2.xaxis.get_minor_locator().subticks = frequency
-        self._ax2.yaxis.get_minor_locator().subticks = frequency_y
+        self._ax1.xaxis.get_minor_locator().subticks = xfrequency
+        self._ax1.yaxis.get_minor_locator().subticks = yfrequency
+        self._ax2.xaxis.get_minor_locator().subticks = xfrequency
+        self._ax2.yaxis.get_minor_locator().subticks = yfrequency
 
     @auto_refresh
     def show(self):


### PR DESCRIPTION
Without break compatibility with previous versions, now the user can specify a different frequency for the minor ticks on each axis.
set_minor_frequency now accepts two arguments (the frequency for xaxis and for yaxis) instead of only one. If the second one is not supplied, then it produces the same behavior than previously (the same frequency for both axes).

This avoids ending with ticks that were only useful for one of the axis because they produced not standard intervals in the other axis.
