### PR TITLE
coordinate labels in LaTeX now in roman

### DIFF
--- a/aplpy/labels.py
+++ b/aplpy/labels.py
@@ -412,7 +412,7 @@ class WCSFormatter(mpl.Formatter):
                 sep = (':', ':', '')
             elif label_style == 'plain_tex':
                 if hours:
-                    sep = ('^{h}', '^{m}', '^{s}')
+                    sep = ('^{\\rm h}', '^{\\rm m}', '^{\\rm s}')
                 else:
                     sep = ('^{\circ}', '^{\prime}', '^{\prime\prime}')
 


### PR DESCRIPTION
When the labels are displayed in LaTeX, the unit symbols for the right ascension coordinates (that is, the h, m, s, for hour, minute, and second, respectively) were shown in math mode, and thus in italic form.
To verify the standards of the International System of Units, the units h,m,s must be displayed in roman mode, and not in italic one.

This request fixes this behavior and now the unit symbols are displayed in roman mode.
