### PR TITLE
Correct names for surface brightness units related to issue 296

### DIFF
--- a/aplpy/tests/data/2d_fits/1904-66_HPX.hdr
+++ b/aplpy/tests/data/2d_fits/1904-66_HPX.hdr
@@ -6,7 +6,7 @@ NAXIS2  =                  192 / length of data axis 2
 EXTEND  =                    T / FITS dataset may contain extensions
 COMMENT   FITS (Flexible Image Transport System) format is defined in 'Astronomy
 COMMENT   and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H
-BUNIT   = 'Jy/beam '           / Pixel value is flux density
+BUNIT   = 'Jy/beam '           / Pixel value is surface brightness
 CTYPE1  = 'RA---HPX'
 CRPIX1  =    -8.21754831338666
 CDELT1  =  -0.0666666666666667

--- a/aplpy/tests/test_colorbar.py
+++ b/aplpy/tests/test_colorbar.py
@@ -83,7 +83,7 @@ def test_colorbar_axis_label():
     f = FITSFigure(data)
     f.show_grayscale()
     f.add_colorbar()
-    f.colorbar.set_axis_label_text('Flux (MJy/sr)')
+    f.colorbar.set_axis_label_text('Surface Brightness (MJy/sr)')
     f.colorbar.set_axis_label_rotation(45.)
     f.colorbar.set_axis_label_font(size='small', weight='bold', stretch='normal',
                                    family='serif', style='normal', variant='normal')

--- a/docs/quick_reference.rst
+++ b/docs/quick_reference.rst
@@ -174,7 +174,7 @@ Once :meth:`~aplpy.aplpy.FITSFigure.add_colorbar` has been called, the ``fig.col
 
 * Add a colorbar label::
 
-    f.colorbar.set_axis_label_text('Flux (Jy/beam)')
+    f.colorbar.set_axis_label_text('Surface Brightness (Jy/beam)')
 
 * Set some of the colorbar label properties::
 


### PR DESCRIPTION
A few small changes to the name associated with Jy/beam and MJy/sr. Changed from flux or flux density to surface brightness. Originally brought up in this [issue](https://github.com/aplpy/aplpy/issues/296). Since I found a couple other spots where this was wrong compared to my original issue, I included fixing those as well.