### PR TITLE
Added 'exp' and 'sci' options for colorbar tick label formatting

### DIFF
--- a/aplpy/colorbar.py
+++ b/aplpy/colorbar.py
@@ -30,9 +30,9 @@ class Colorbar(object):
         self._axislabel_fontproperties = FontProperties()
 
     @auto_refresh
-    def show(self, location='right', width=0.2, pad=0.05, ticks=None, labels=True, log_format=False,
-             box=None, box_orientation='vertical', axis_label_text=None, axis_label_rotation=None,
-             axis_label_pad=5):
+    def show(self, location='right', width=0.2, pad=0.05, ticks=None, labels=True, format=None,
+             sig_digits=0, box=None, box_orientation='vertical', axis_label_text=None, 
+             axis_label_rotation=None, axis_label_pad=5):
         '''
         Show a colorbar on the side of the image.
 
@@ -54,8 +54,12 @@ class Colorbar(object):
         labels : bool, optional
             Whether to show numerical labels.
 
-        log_format : bool, optional
-            Whether to format ticks in exponential notation
+        format : str, optional
+            Format of the colorbar tick labels. Can be 'exp' (exponential 
+            notation) or 'sci' (scientific notation). Default is None.
+
+        sig_digits: int, optional
+            Number of significant digits if format is set to 'sci'.
 
         box : list, optional
             A custom box within which to place the colorbar. This should
@@ -75,7 +79,8 @@ class Colorbar(object):
         self._base_settings['pad'] = pad
         self._base_settings['ticks'] = ticks
         self._base_settings['labels'] = labels
-        self._base_settings['log_format'] = log_format
+        self._base_settings['format'] = format
+        self._base_settings['sig_digits'] = sig_digits
         self._base_settings['box'] = box
         self._base_settings['box_orientation'] = box_orientation
         self._base_settings['axis_label_text'] = axis_label_text
@@ -119,10 +124,12 @@ class Colorbar(object):
                 self._colorbar_axes = self._parent._figure.add_axes(box)
                 orientation = box_orientation
 
-            if log_format:
-                format=LogFormatterMathtext()
+            if format == 'exp':
+                format = LogFormatterMathtext()
+            elif format == 'sci':
+                format = '%.' + str(sig_digits) + 'e'
             else:
-                format=None
+                format = None
 
             self._colorbar = self._parent._figure.colorbar(self._parent.image, cax=self._colorbar_axes,
                                                            orientation=orientation, format=format,


### PR DESCRIPTION
By default, the default colorbar format can occasionally lead to ugly results if the values in the image are very large. In the figure attached, you can see how 1e-7 is shown on the image (rather hard to see it, so you'll probably need to zoom in). This could be fixed by moving the colorbar higher up, but I find the space between the colorbar and the image to be rather big then, especially if the tick labels use larger fonts. In matplotlib, one could set an offset for 1e-7, but this does not seem possible here. As an alternative, I think it would be good if the user had the option between exponential format (as one can now do by setting log_format=True) and scientific format. You can see the results with the different formats in the attached image.
![colorbar-examples](https://cloud.githubusercontent.com/assets/6616486/16032246/de44c806-31b8-11e6-9caa-2133b36285bc.jpg)
