### PR TITLE
Use axis.axes property instead of get_axes()

### DIFF
--- a/aplpy/ticks.py
+++ b/aplpy/ticks.py
@@ -306,11 +306,11 @@ class WCSLocator(Locator):
 
         self.coord_type = self._wcs.xaxis_coord_type if self.coord == 'x' else self._wcs.yaxis_coord_type
 
-        ymin, ymax = self.axis.get_axes().yaxis.get_view_interval()
-        xmin, xmax = self.axis.get_axes().xaxis.get_view_interval()
+        ymin, ymax = self.axis.axes.yaxis.get_view_interval()
+        xmin, xmax = self.axis.axes.xaxis.get_view_interval()
 
         if self.axis.apl_auto_tick_spacing:
-            self.axis.apl_tick_spacing = default_spacing(self.axis.get_axes(), self.coord, self.axis.apl_label_form)
+            self.axis.apl_tick_spacing = default_spacing(self.axis.axes, self.coord, self.axis.apl_label_form)
             if self.axis.apl_tick_spacing is None:
                 self.axis.apl_tick_positions_pix = []
                 self.axis.apl_tick_positions_world = []


### PR DESCRIPTION
Matplotlib has deprecated get_axes() in favor of the axes property.
I haven't tested which versions of mpl support the axes property, but since this PR targets APLpy 2, I'd assume the matplotlib version dependency should be ok.
Fixes #294 
