### PR TITLE
fix the bug with HDUList

### DIFF
--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -329,7 +329,7 @@ class FITSFigure(Layers, Regions, Deprecated):
 
             hdu = data
 
-        elif isinstance(data, HDUList):
+        elif isinstance(data, fits.HDUList):
 
             hdu = data[hdu]
 


### PR DESCRIPTION
Hi,

there is a trivial error in aplpy that is triggered when reading files with the list of HDUs. See exception below. The one liner fix is in the pull request. I guess this needs to be added to the list of tests. I think currently there is no test of FitsFigure with the proper HDUList in the file. I didn't have time to write the test though.

```
In [2]: get_dss.get_dss(180,30)
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-2-16359f16ef2a> in <module>()
----> 1 get_dss.get_dss(180,30)

/home/koposov/astrolibpy/my_utils/get_dss.py in get_dss(ra, dec, survey, radius, debug, noerase, subplot)
     30         if not noerase:
     31                 plt.clf()
---> 32         gc=aplpy.FITSFigure(dat,figure=plt.gcf(),subplot=subplot)
     33         gc.set_tick_labels_format('ddd.dddd','ddd.dddd')
     34         gc.show_grayscale()

/home/koposov/local2/soft/pyenv3/lib/python3.5/site-packages/aplpy/core.py in __init__(self, data, hdu, figure, subplot, downsample, north, convention, dimensions, slices, auto_refresh, **kwargs)

/home/koposov/local2/soft/pyenv3/lib/python3.5/site-packages/aplpy/decorators.py in _auto_refresh(f, *args, **kwargs)
     23     mydata.nesting = getattr(mydata, 'nesting', 0) + 1
     24     try:
---> 25         return f(*args, **kwargs)
     26     finally:
     27         mydata.nesting -= 1

/home/koposov/local2/soft/pyenv3/lib/python3.5/site-packages/aplpy/core.py in __init__(self, data, hdu, figure, subplot, downsample, north, convention, dimensions, slices, auto_refresh, **kwargs)
    215         else:
    216             self._data, self._header, self._wcs = self._get_hdu(data, hdu, north, \
--> 217                 convention=convention, dimensions=dimensions, slices=slices)
    218             self._wcs.nx = self._header['NAXIS%i' % (dimensions[0] + 1)]
    219             self._wcs.ny = self._header['NAXIS%i' % (dimensions[1] + 1)]

/home/koposov/local2/soft/pyenv3/lib/python3.5/site-packages/aplpy/core.py in _get_hdu(self, data, hdu, north, convention, dimensions, slices)
    330             hdu = data
    331 
--> 332         elif isinstance(data, HDUList):
    333 
    334             hdu = data[hdu]

NameError: name 'HDUList' is not defined
```