### PR TITLE
Removing workaround of qt version pinning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=stable
         - MATPLOTLIB_VERSION=1.5
-        - CONDA_DEPENDENCIES='nose pyqt matplotlib pillow qt=4 pyqt=4 pyregion'
+        - CONDA_DEPENDENCIES='nose pyqt matplotlib pillow pyregion'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
         - PIP_DEPENDENCIES='pytest-mpl'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,10 @@ matrix:
           env: NUMPY_VERSION=1.9 MATPLOTLIB_VERSION=1.4 SETUP_CMD='test --remote-data'
         - python: 2.7
           env: NUMPY_VERSION=1.8 MATPLOTLIB_VERSION=1.4 SETUP_CMD='test --remote-data'
+               CONDA_DEPENDENCIES='nose pyqt=4 matplotlib pillow'
         - python: 2.7
           env: NUMPY_VERSION=1.7 MATPLOTLIB_VERSION=1.4 SETUP_CMD='test --remote-data'
+               CONDA_DEPENDENCIES='nose pyqt=4 matplotlib pillow'
 
 before_install:
 


### PR DESCRIPTION
The qt version issue seems to be resolved, so this workaround can be removed now.
