### PR TITLE
Fix issues with region parsing/plotting

### DIFF
--- a/aplpy/regions.py
+++ b/aplpy/regions.py
@@ -2,12 +2,11 @@ from __future__ import absolute_import, print_function, division
 
 from astropy.extern import six
 from astropy import log
-from astropy import wcs
 
 from .decorators import auto_refresh
 
 
-class Regions:
+class Regions(object):
     """
     Regions sub-class of APLpy.
 

--- a/aplpy/regions.py
+++ b/aplpy/regions.py
@@ -62,7 +62,7 @@ class Regions:
             ds9 call and onto the patchcollections.
         """
 
-        PC, TC = ds9(region_file, wcs.WCS(self._header).sub([wcs.WCSSUB_CELESTIAL]), **kwargs)
+        PC, TC = ds9(region_file, flatten_header(self._header), **kwargs)
 
         # ffpc = self._ax1.add_collection(PC)
         PC.add_to_axes(self._ax1)
@@ -172,3 +172,26 @@ class ArtistCollection():
     def set_zorder(self, zorder):
         for T in self.artistlist:
             T.set_zorder(zorder)
+
+
+def flatten_header(header):
+    """
+    Attempt to turn an N-dimensional fits header into a 2-dimensional header
+    Turns all CRPIX[>2] etc. into new keywords with suffix 'A'
+    """
+
+    newheader = header.copy()
+
+    for key in newheader.keys():
+        try:
+            if int(key[-1]) >= 3 and key[:2] in ['CD','CR','CT','CU','NA']:
+                newheader.rename_key(key,'A'+key,force=True)
+        except ValueError:
+            # if key[-1] is not an int
+            pass
+        except IndexError:
+            # if len(key) < 2
+            pass
+    newheader.update('NAXIS',2)
+
+    return newheader

--- a/aplpy/regions.py
+++ b/aplpy/regions.py
@@ -192,6 +192,6 @@ def flatten_header(header):
         except IndexError:
             # if len(key) < 2
             pass
-    newheader.update('NAXIS',2)
+    newheader['NAXIS'] = 2
 
     return newheader

--- a/aplpy/regions.py
+++ b/aplpy/regions.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 from astropy.extern import six
 from astropy import log
+from astropy import wcs
 
 from .decorators import auto_refresh
 
@@ -179,18 +180,10 @@ def flatten_header(header):
     Turns all CRPIX[>2] etc. into new keywords with suffix 'A'
     """
 
-    newheader = header.copy()
-
-    for key in newheader.keys():
-        try:
-            if int(key[-1]) >= 3 and key[:2] in ['CD','CR','CT','CU','NA']:
-                newheader.rename_key(key,'A'+key,force=True)
-        except ValueError:
-            # if key[-1] is not an int
-            pass
-        except IndexError:
-            # if len(key) < 2
-            pass
+    orig_wcs = wcs.WCS(header)
+    newheader = orig_wcs.celestial.to_header()
     newheader['NAXIS'] = 2
+    newheader['NAXIS1'] = header['NAXIS{0}'.format(orig_wcs.wcs.lng+1)]
+    newheader['NAXIS2'] = header['NAXIS{0}'.format(orig_wcs.wcs.lat+1)]
 
     return newheader


### PR DESCRIPTION
Since pyregion no longer accepts WCS objects, we have to pass it a Header object, which means doing the very unfortunate and hacky direct header keyword manipulation I had previously tried to avoid.  This is an unfortunate indirect consequence of the loss of `.naxis*` that has slowly reverberated throughout the astropy ecosystem...

See also:
https://github.com/astropy/astropy/issues/4669
https://github.com/aplpy/aplpy/pull/284
https://github.com/astropy/astropy/pull/5411