### PR TITLE
Fix deprecation for axes_grid

### DIFF
--- a/aplpy/colorbar.py
+++ b/aplpy/colorbar.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, division
 import warnings
 
 import matplotlib.axes as maxes
-from mpl_toolkits.axes_grid import make_axes_locatable
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.font_manager import FontProperties
 from matplotlib.ticker import LogFormatterMathtext
 

--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -11,7 +11,8 @@ if version.LooseVersion(matplotlib.__version__) < version.LooseVersion('1.0.0'):
     raise Exception("matplotlib 1.0.0 or later is required for APLpy")
 
 import matplotlib.pyplot as mpl
-import mpl_toolkits.axes_grid1.parasite_axes as mpltk
+from mpl_toolkits.axes_grid1 import parasite_axes
+from mpl_toolkits.axisartist.axislines import Axes
 from astropy.extern import six
 
 from astropy.wcs import WCS
@@ -233,10 +234,12 @@ class FITSFigure(Layers, Regions, Deprecated):
             self._figure = mpl.figure(**kwargs)
 
         # Create first axis instance
+        HostAxes = parasite_axes.host_axes_class_factory(axes_class=Axes)
         if type(subplot) == list and len(subplot) == 4:
-            self._ax1 = mpltk.HostAxes(self._figure, subplot, adjustable='datalim')
+            self._ax1 = HostAxes(self._figure, subplot, adjustable='datalim')
         elif type(subplot) == tuple and len(subplot) == 3:
-            self._ax1 = mpltk.SubplotHost(self._figure, *subplot)
+            SubplotHost = parasite_axes.subplot_class_factory(HostAxes)
+            self._ax1 = SubplotHost(self._figure, *subplot)
         else:
             raise ValueError("subplot= should be either a tuple of three values, or a list of four values")
 

--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -11,7 +11,7 @@ if version.LooseVersion(matplotlib.__version__) < version.LooseVersion('1.0.0'):
     raise Exception("matplotlib 1.0.0 or later is required for APLpy")
 
 import matplotlib.pyplot as mpl
-import mpl_toolkits.axes_grid.parasite_axes as mpltk
+import mpl_toolkits.axes_grid1.parasite_axes as mpltk
 from astropy.extern import six
 
 from astropy.wcs import WCS

--- a/aplpy/overlays.py
+++ b/aplpy/overlays.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 import warnings
 
-from mpl_toolkits.axes_grid.anchored_artists \
+from mpl_toolkits.axes_grid1.anchored_artists \
     import AnchoredEllipse, AnchoredSizeBar
 
 import numpy as np


### PR DESCRIPTION
Looks like `mpl_toolkits.axes_grid` is deprecated in new `matplotlib` versions, as importing `aplpy` triggers a deprecation warning (`mpl.__version__ = 2.0.2+4333.g1bf8282`):

```
The mpl_toolkits.axes_grid module was deprecated in version 2.1. Use mpl_toolkits.axes_grid1 and mpl_toolkits.axisartist provies the same functionality instead.
```

The second commit is needed because some functionality for `axes_grid`, like the `toggle_axislines` method, was [moved](https://github.com/matplotlib/matplotlib/commit/867d6f1fd05c1377feab5190e289ed6328307b81) to `axisartist`. I've rewired `axes_grid` through `axes_grid1` and `axisartist`, following the [exact same way](https://github.com/matplotlib/matplotlib/blob/b17e5d68e12c40c61bf972a084aa137d839a57d3/lib/mpl_toolkits/axes_grid/parasite_axes.py) the deprecated parasite axes are being wrapped around the up-to-date modules.