### PR TITLE
Removes remaining image_util dependence [#364]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ CHANGES
 1.2 (unreleased)
 ----------------
 
-- No changes yet.
+- Remaining ``image_util`` is replaced by ``astropy.visualization``. [#364]
 
 1.1.1 (2016-10-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,14 @@ CHANGES
 2.0 (unreleased)
 ----------------
 
-- Refactored APLpy to make use of WCSAxes to draw coordinate frames. [#239]
+- Refactored APLpy to make use of WCSAxes to draw coordinate frames. [#239, #364]
 
 - Use reproject package instead of montage-wrapper and Montage.
 
 1.2 (unreleased)
 ----------------
 
-- Remaining ``image_util`` is replaced by ``astropy.visualization``. [#364]
+- No changes yet.
 
 1.1.1 (2016-10-04)
 ------------------

--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -928,12 +928,13 @@ class FITSFigure(Layers, Regions):
         wcs_contour.ny = header_contour['NAXIS%i' % (dimensions[1] + 1)]
 
         image_contour = convolve_util.convolve(data_contour, smooth=smooth, kernel=kernel)
-
         if type(levels) == int:
-            auto_levels = image_util.percentile_function(image_contour)
-            vmin = auto_levels(0.25)
-            vmax = auto_levels(99.75)
-            levels = np.linspace(vmin, vmax, levels)
+            interval = AsymmetricPercentileInterval(0.25, 99.75, n_samples=10000)
+            try:
+                vmin_auto, vmax_auto = interval.get_limits(image_contour)
+            except IndexError:  # no valid values
+                vmin_auto = vmax_auto = 0
+            levels = np.linspace(vmin_auto, vmax_auto, levels)
 
         if wcs_contour.wcs.ctype[self.x] == 'PIXEL' or wcs_contour.wcs.ctype[self.y] == 'PIXEL':
             frame = 'pixel'


### PR DESCRIPTION
The change is a trivial update following 699edb9c9d98996b15f58fde5690030dc9fcb63c.

On my machine, the tests passed by
```
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_axis_labels.py ......
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_beam.py ............................
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_colorbar.py ........
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_contour.py ..
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_convolve.py ....
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_downsample.py .
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_frame.py ..
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_grid.py .......
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_images.py sssssssss
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_init_cube.py ...........................x
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_init_image.py ...........................................................................
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_misc.py .
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_pixworldmarkers.py ..............
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_rgb.py s
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_save.py ........................
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_scalebar.py ...............
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_subplot.py ......
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_tick_labels.py ......
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_ticks.py ......
../../anaconda3/envs/aplpy_dev/lib/python3.6/site-packages/aplpy-0.0.dev1007-py3.6.egg/aplpy/tests/test_vectors.py ss
========================================== 232 passed, 12 skipped, 1 xfailed, 152 warnings in 28.68 seconds ==========================================
```