### PR TITLE
Reintroduce compass class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installing
 The following dependencies are required:
 
 -  `Numpy <http://www.numpy.org>`__ 1.11 or later
--  `Matplotlib <http://www.matplotlib.org>`__ 2.0 or later
+-  `Matplotlib <http://www.matplotlib.org>`__ 3.0 or later
 -  `Astropy <http://www.astropy.org>`__ 3.1 or later
 -  `reproject <https://reproject.readthedocs.org>`__ 0.4 or later
 -  `PyAVM <http://astrofrog.github.io/pyavm/>`__ 0.9.4 or later

--- a/aplpy/__init__.py
+++ b/aplpy/__init__.py
@@ -15,7 +15,7 @@ if not _ASTROPY_SETUP_:  # noqa
     from .rgb import make_rgb_image, make_rgb_cube  # noqa
 
     from .frame import Frame  # noqa
-    from .overlays import Scalebar, Beam  # noqa
+    from .overlays import Compass, Scalebar, Beam  # noqa
     from .colorbar import Colorbar  # noqa
     from .grid import Grid  # noqa
     from .ticks import Ticks  # noqa

--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -32,7 +32,7 @@ from .grid import Grid
 from .ticks import Ticks
 from .tick_labels import TickLabels
 from .axis_labels import AxisLabels
-from .overlays import Beam, Scalebar
+from .overlays import Beam, Scalebar, Compass
 from .regions import Regions
 from .colorbar import Colorbar
 from .frame import Frame
@@ -2005,6 +2005,64 @@ class FITSFigure(Layers, Regions):
 
             self.beam._remove()
             del self.beam
+
+    @auto_refresh
+    def add_compass(self, **kwargs):
+        """
+        Add a compass to the current figure.
+
+        Once this method has been run, a compass attribute becomes
+        available, and can be used to control the aspect of the compass::
+
+            >>> f = aplpy.FITSFigure(...)
+            >>> ...
+            >>> f.add_compass()
+            >>> f.compass.set_color('firebrick')
+            >>> ...
+
+        Parameters
+        ----------
+
+        length : float or quantity, optional
+            The length of the compass arrows in degrees, an angular quantity,
+            or angular unit
+
+        corner : str, optional
+            Where to place the compass. Acceptable values are: 'left',
+            'right', 'top', 'bottom', 'top left', 'top right',
+            'bottom left' (default), 'bottom right'
+
+        frame : bool, optional
+            Whether to display a frame behind the compass (default is False)
+
+        sep_x, sep_y : float or quantity, optional
+            Separation between the arrows and labels in degrees, an angular
+            quantity, or angular unit (defaults are 0.01 and 0.03)
+
+        fontproperties : matplotlib FontProperties, optional
+            Font properties for the label text
+
+        kwargs
+            Additional arguments are passed to the matplotlib TextPath and
+            FancyArrowPatch classes. See the matplotlib documentation for more
+            details.
+        """
+        if hasattr(self, 'compass'):
+            raise Exception("Compass already exists")
+        try:
+            self.compass = Compass(self)
+            self.compass.show(**kwargs)
+        except Exception:
+            del self.compass
+            raise
+
+    @auto_refresh
+    def remove_compass(self):
+        """
+        Removes the compass from the current figure.
+        """
+        self.compass._remove()
+        del self.compass
 
     @auto_refresh
     def add_scalebar(self, length, *args, **kwargs):

--- a/aplpy/tests/test_compass.py
+++ b/aplpy/tests/test_compass.py
@@ -1,0 +1,115 @@
+from __future__ import absolute_import, print_function, division
+
+import os
+
+import pytest
+import numpy as np
+from astropy import units as u
+from astropy.io import fits
+
+from .. import FITSFigure
+
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+HEADER_DIR = os.path.join(ROOT, 'data/2d_fits')
+HEADER = fits.Header.fromtextfile(os.path.join(HEADER_DIR, '1904-66_TAN.hdr'))
+HDU = fits.PrimaryHDU(np.zeros((16, 16)), HEADER)
+
+
+def test_compass_add_invalid():
+    f = FITSFigure(HDU)
+    with pytest.raises(TypeError):
+        f.add_compass()
+
+
+def test_compass_addremove():
+    f = FITSFigure(HDU)
+    f.add_compass()
+    f.remove_compass()
+    f.add_compass()
+    f.close()
+
+
+def test_compass_showhide():
+    f = FITSFigure(HDU)
+    f.add_compass()
+    f.compass.hide()
+    f.compass.show()
+    f.close()
+
+
+def test_compass_length():
+    f = FITSFigure(HDU)
+    f.add_compass(length=0.15)
+    f.compass.set_length(0.01)
+    f.compass.set_length(0.15)
+    f.close()
+
+
+@pytest.mark.parametrize('quantity', [1 * u.arcsec, u.arcsec, 2 * u.degree, 5 * u.radian])
+def test_compass_length_quantity(quantity):
+    f = FITSFigure(HDU)
+    f.add_compass(length=quantity)
+    f.compass.set_length(quantity)
+    f.close()
+
+
+def test_compass_corner():
+    f = FITSFigure(HDU)
+    f.add_compass()
+    for corner in ['top', 'bottom', 'left', 'right', 'top left', 'top right',
+                   'bottom left', 'bottom right']:
+        f.compass.set_corner(corner)
+    f.close()
+
+
+def test_compass_frame():
+    f = FITSFigure(HDU)
+    f.add_compass()
+    f.compass.set_frame(True)
+    f.compass.set_frame(False)
+    f.close()
+
+
+def test_compass_color():
+    f = FITSFigure(HDU)
+    f.add_compass()
+    f.compass.set_color('black')
+    f.compass.set_color('#003344')
+    f.compass.set_color((1.0, 0.4, 0.3))
+    f.close()
+
+
+def test_compass_alpha():
+    f = FITSFigure(HDU)
+    f.add_compass()
+    f.compass.set_alpha(0.1)
+    f.compass.set_alpha(0.2)
+    f.compass.set_alpha(0.5)
+    f.close()
+
+
+def test_compass_linestyle():
+    f = FITSFigure(HDU)
+    f.add_compass()
+    f.compass.set_linestyle('solid')
+    f.compass.set_linestyle('dotted')
+    f.compass.set_linestyle('dashed')
+    f.close()
+
+
+def test_compass_linewidth():
+    f = FITSFigure(HDU)
+    f.add_compass()
+    f.compass.set_linewidth(0)
+    f.compass.set_linewidth(1)
+    f.compass.set_linewidth(5)
+    f.close()
+
+
+def test_compass_font():
+    f = FITSFigure(HDU)
+    f.add_compass()
+    f.compass.set_font(size='small', weight='bold', stretch='normal',
+                       family='serif', style='normal', variant='normal')
+    f.close()

--- a/docs/fitsfigure/quick_reference.rst
+++ b/docs/fitsfigure/quick_reference.rst
@@ -221,6 +221,64 @@ Once :meth:`~aplpy.FITSFigure.add_grid` has been called, the ``fig.grid`` object
     fig.grid.set_linestyle('solid')
     fig.grid.set_linewidth(1)  # points
 
+Compass
+^^^^^^^
+
+A compass can be added and removed using the following commands::
+
+    fig.add_compass()
+    fig.remove_compass()
+
+Once :meth:`~aplpy.FITSFigure.add_compass` has been called, the ``fig.compass`` object is created and the following methods are then available:
+
+* Show and hide the compass::
+
+    fig.compass.show(length=0.2)  # length in degrees
+    fig.compass.hide()
+
+* Change the length of the compass::
+
+    fig.compass.set_length(0.02)  # degrees
+
+* Specify the length of the compass in different units::
+
+    from astropy import units as u
+    fig.compass.set_length(72 * u.arcsecond)
+
+* Change the corner that the compass is shown in::
+
+    fig.compass.set_corner('top right')
+
+  This can be one of ``top right``, ``top left``, ``bottom right``,
+  ``bottom left``, ``left``, ``right``, ``bottom`` or ``top``.
+
+* Set whether or not to show a frame around the compass::
+
+    fig.compass.set_frame(False)
+
+* Set the transparency level of the compass and labels::
+
+    fig.compass.set_alpha(0.7)
+
+* Set the color of the compass and labels::
+
+    fig.compass.set_color('white')
+
+* Set the font properties of the labels::
+
+    fig.compass.set_font(size='medium', weight='medium', \
+                         stretch='normal', family='sans-serif', \
+                         style='normal', variant='normal')
+
+* Set the line style and width for the compass arrows::
+
+    fig.compass.set_linestyle('solid')
+    fig.compass.set_linewidth(3)  # points
+
+* Set multiple properties at once::
+
+    fig.compass.set(linestyle='solid', color='red', ...)
+
 Scalebar
 ^^^^^^^^
 


### PR DESCRIPTION
This is for implementing a working compass class for #10.

I think it's worth noting that this requires matplotlib 3.0+ since it is built on AnchoredDirectionArrows. I don't want to surprise anyone with a change to one of the major dependencies.

I have successfully tested on just a couple coordinate systems (RA Dec, Galactic) but it should probably have more thrown at it. I didn't have much luck finding example FITS images (e.g. ecliptic, alt az, supergalactic) but I can give it a go if I get directed to some (or a way to convert between them with astropy).

I did have issue with an [all-sky map](https://astropy.stsci.edu/data/allsky/allsky_rosat.fits), where it crashed with ```'path' is not a valid quadratic Bezier curve```. I can give more details if they are needed, but I thought I'd get the ball rolling and see how people feel that use case should be sorted out.

Last note is a warning, I am new to pytest so I didn't actually run the code in test_compass.py. It's essentially copied from the scalebar and beam tests but it may need tweaking once it can actually be run.