### PR TITLE
fix for bugs #435 and 433. Tick referenced ax instead of _ax

### DIFF
--- a/aplpy/ticks.py
+++ b/aplpy/ticks.py
@@ -17,8 +17,8 @@ class Ticks(object):
         or into the axes (``in``).
         """
         if direction in ('in', 'out'):
-            self.ax.coords[self.x].ticks.set_tick_out(direction == 'out')
-            self.ax.coords[self.y].ticks.set_tick_out(direction == 'out')
+            self._ax.coords[self.x].ticks.set_tick_out(direction == 'out')
+            self._ax.coords[self.y].ticks.set_tick_out(direction == 'out')
         else:
             raise ValueError("direction should be 'in' or 'out'")
 


### PR DESCRIPTION
This is a fix for bugs 435 and 433.  A typo in the master branch code causes an exception when trying to set tick direction.
