### PR TITLE
Updates test_save.py for matplotlib 3.4

### DIFF
--- a/aplpy/tests/test_save.py
+++ b/aplpy/tests/test_save.py
@@ -27,7 +27,7 @@ def is_format(filename, format):
         return f.read(14) == b'%!PS-Adobe-3.0'
     elif format == 'svg':
         from xml.dom import minidom
-        return minidom.parse(f).childNodes[2].attributes['xmlns'].value == 'http://www.w3.org/2000/svg'
+        return minidom.parse(f).childNodes[-1].attributes['xmlns'].value == 'http://www.w3.org/2000/svg'
     else:
         raise Exception("Unknown format: %s" % format)
 


### PR DESCRIPTION
When updating from matplotlib 3.3.4 to matplotlib 3.4.1, I noticed the following errors in the test suite: https://gist.github.com/rmcgibbo/60f94457ca5852e96843feda27596910

This patch should fix test_save.py to be compatible with the new version of matplotlib as well as the old version. The change is that there's no more "comment" node in the SVG, so the offsets are shifted by 1 and what was previously childNode[2] is now childNode[1].