### PR TITLE
Get wraps from functools instead of astropy

### DIFF
--- a/aplpy/decorators.py
+++ b/aplpy/decorators.py
@@ -1,6 +1,6 @@
 import threading
 
-from astropy.utils.decorators import wraps
+from functools import wraps
 
 mydata = threading.local()
 


### PR DESCRIPTION
This fixes compatibility with astropy 5.0.1, similar to https://github.com/astropy/pyvo/pull/283