### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -1,4 +1,4 @@
-from distutils import version
+from setuptools._distutils import version
 import os
 import operator
 from functools import reduce

--- a/aplpy/rgb.py
+++ b/aplpy/rgb.py
@@ -1,4 +1,4 @@
-from distutils import version
+from setuptools._distutils import version
 import os
 import warnings
 


### PR DESCRIPTION
This quick fix allows to build aplpy with python 3.12 until the package infrastructure is updated (see #497). Closes #494.