### PR TITLE
Use FK4/FK5 instances instead of classes to get the equinox year

### DIFF
--- a/aplpy/axis_labels.py
+++ b/aplpy/axis_labels.py
@@ -44,13 +44,13 @@ class AxisLabels(object):
 
         elif isinstance(frame, FK5):
 
-            equinox = "{:g}".format(FK5.equinox.jyear)
+            equinox = "{:g}".format(frame.equinox.jyear)
             xtext = 'RA (J{0})'.format(equinox)
             ytext = 'Dec (J{0})'.format(equinox)
 
         elif isinstance(frame, FK4):
 
-            equinox = "{:g}".format(FK4.equinox.byear)
+            equinox = "{:g}".format(frame.equinox.byear)
             xtext = 'RA (B{0})'.format(equinox)
             ytext = 'Dec (B{0})'.format(equinox)
 


### PR DESCRIPTION
During a code reorganization in Astropy 6.1, the jyear/byear attribute is no  longer a  class attribute in  astropy.coordinates.equinox, but  only an instance  attribute.

This makes a number of tests fail like
```Python
 _____________________________ test_beam_add_remove _____________________________
    def test_beam_add_remove():
>       f = FITSFigure(HDU)
[…]
>           equinox = "{:g}".format(FK5.equinox.jyear)
E           AttributeError: 'TimeAttribute' object has no attribute 'jyear'
 
/usr/lib/python3/dist-packages/aplpy/axis_labels.py:47: AttributeError
```

 As discussed in https://github.com/astropy/astropy/issues/16654, the best way to fix it is here. Aside of adopting the (onforeseen) API change, it may  be  useful to  take the  possibily modified equinox time hear instead of the default one.

Closes: https://github.com/astropy/astropy/issues/16654
