### PR TITLE
BUG: fix an incompatibility with matplotlib 3.9 (plt.cm has no attribute get_cmap)

### DIFF
--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -664,7 +664,7 @@ class FITSFigure(Layers, Regions):
         max_auto = vmax is None
 
         # The set of available functions
-        cmap = plt.cm.get_cmap(cmap)
+        cmap = plt.colormaps[cmap]
 
         if min_auto or max_auto:
 
@@ -915,9 +915,9 @@ class FITSFigure(Layers, Regions):
             self.remove_layer(layer, raise_exception=False)
 
         if cmap:
-            cmap = plt.cm.get_cmap(cmap)
+            cmap = plt.colormaps[cmap]
         elif not colors:
-            cmap = plt.cm.get_cmap('viridis')
+            cmap = plt.colormaps['viridis']
 
         if data is not None:
             data_contour, header_contour, wcs_contour, wcsaxes_slices = \
@@ -1844,7 +1844,7 @@ class FITSFigure(Layers, Regions):
             self._figure.apl_grayscale_invert_default = False
             self._figure.apl_colorscale_cmap_default = 'viridis'
             if self.image:
-                self.image.set_cmap(cmap=plt.cm.get_cmap('viridis'))
+                self.image.set_cmap(cmap=plt.colormaps['viridis'])
         elif theme == 'publication':
             self.frame.set_color('black')
             self.frame.set_linewidth(1.0)


### PR DESCRIPTION
This function was deprecated in matplotlib 3.5](https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.5.0.html#colormap-registry-experimental) and [moved in matplotlib 3.9](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#removals). It looks like this problem is responsible for most (maybe all) failing tests ([example logs](https://github.com/aplpy/aplpy/actions/runs/9766664618/job/26960172172))
Since this package already requires matplotlib>=3.5, there's no need for a compatibility layer and we can just switch to new supported API.